### PR TITLE
chore: update TypeScript and dependency configurations

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -21,10 +21,10 @@
     "devDependencies": {
         "@types/cookie-parser": "^1.4.8",
         "@types/cors": "^2.8.17",
-        "@types/express": "^4.17.21",
+        "@types/express": "^4.17.22",
         "@types/jsonwebtoken": "^9.0.5",
         "@types/morgan": "^1.9.9",
-        "@types/node": "^22.15.6",
+        "@types/node": "^22.15.30",
         "cross-env": "^7.0.3",
         "nodemon": "^3.1.10",
         "prettier": "^3.5.3",

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,7 +9,8 @@
         "forceConsistentCasingInFileNames": true,
         "outDir": "dist",
         "sourceMap": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "types": ["node"]
     },
     "include": ["src/**/*"],
     "exclude": ["node_modules", "dist"],


### PR DESCRIPTION
This pull request includes updates to development dependencies and TypeScript configuration for the backend. The updates ensure compatibility with newer versions of dependencies and improve TypeScript type resolution.

### Dependency Updates:
* [`backend/package.json`](diffhunk://#diff-495707834ca4b862f9acdfbac70d279023d2c059da13db59594e61ed3354fed5L24-R27): Updated `@types/express` to version `4.17.22` and `@types/node` to version `22.15.30` to align with the latest type definitions.

### TypeScript Configuration:
* [`backend/tsconfig.json`](diffhunk://#diff-51d542ab300c6cf7a818e8f0a040fcdb457919b89ac00e22728051097ffe294aL12-R13): Added `"types": ["node"]` to the TypeScript configuration to explicitly include Node.js type definitions, improving type resolution.