### PR TITLE
chore: simplify TypeScript configuration by removing unnecessary type…

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,8 +9,7 @@
         "forceConsistentCasingInFileNames": true,
         "outDir": "dist",
         "sourceMap": true,
-        "resolveJsonModule": true,
-        "types": ["node"]
+        "resolveJsonModule": true
     },
     "include": ["src/**/*"],
     "exclude": ["node_modules", "dist"],


### PR DESCRIPTION
This pull request includes a small change to the `backend/tsconfig.json` file. The change removes the `"types": ["node"]` configuration from the `compilerOptions` section, which may impact type definitions for Node.js modules.…s entry