### PR TITLE
chore: update TypeScript configuration to allow implicit 'any' type

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,7 +9,8 @@
         "forceConsistentCasingInFileNames": true,
         "outDir": "dist",
         "sourceMap": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "noImplicitAny": false
     },
     "include": ["src/**/*"],
     "exclude": ["node_modules", "dist"],


### PR DESCRIPTION
This pull request introduces a minor configuration update to the TypeScript compiler settings. The change involves disabling the `noImplicitAny` rule in the `backend/tsconfig.json` file.

* [`backend/tsconfig.json`](diffhunk://#diff-51d542ab300c6cf7a818e8f0a040fcdb457919b89ac00e22728051097ffe294aL12-R13): Added `"noImplicitAny": false` to the TypeScript compiler options, allowing implicit `any` types in the codebase.