### PR TITLE
chore: remove default localhost URL from API client configuration

### DIFF
--- a/frontend/src/services/api-client.ts
+++ b/frontend/src/services/api-client.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:5000";
+const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
 
 export const apiClient = axios.create({
   baseURL,


### PR DESCRIPTION
This pull request includes a small change to the `api-client.ts` file. The change removes the fallback URL for the `baseURL` to ensure the application strictly uses the environment variable `NEXT_PUBLIC_BACKEND_URL`.