### PR TITLE
chore: remove default localhost URL from CORS configuration

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,7 +6,7 @@ import morganMiddleware from "./middleware/morgan.middleware.js";
 const app = express();
 app.use(
     cors({
-        origin: process.env.FRONTEND_URL ?? "http://localhost:3000",
+        origin: process.env.FRONTEND_URL,
         credentials: true,
     })
 );


### PR DESCRIPTION
This pull request makes a small adjustment to the CORS configuration in the `backend/src/app.ts` file. The change removes the fallback default value for the `origin` property, ensuring that the `FRONTEND_URL` environment variable is explicitly required.

* [`backend/src/app.ts`](diffhunk://#diff-8455472d7e00dd51813de7e63e5b214382a247990f84bf3fbed9fcc3af24ad6fL9-R9): Updated the `cors` middleware configuration to remove the fallback value of `"http://localhost:3000"` for the `origin` property. Now, only the value of `process.env.FRONTEND_URL` will be used.